### PR TITLE
Proposal for command event simplification

### DIFF
--- a/XPLDirectDevices/lib/Button/Button.cpp
+++ b/XPLDirectDevices/lib/Button/Button.cpp
@@ -42,36 +42,16 @@ void Button::handle(bool input)
     if (_state == 0)
     {
       _state = DEBOUNCE_DELAY;
-      _transition = ePressed;
+      XP.commandStart(_cmdPush);
     }
   }
   else if (_state > 0)
   {
     if (--_state == 0)
     {
-      _transition = eReleased;
+      XP.commandEnd(_cmdPush);
     }
   }
-}
-
-bool Button::pressed()
-{
-  if (_transition == ePressed)
-  {
-    _transition = eNone;
-    return true;
-  }
-  return false;
-}
-
-bool Button::released()
-{
-  if (_transition == eReleased)
-  {
-    _transition = eNone;
-    return true;
-  }
-  return false;
 }
 
 bool Button::engaged()
@@ -87,32 +67,6 @@ void Button::setCommand(int cmdPush)
 int Button::getCommand()
 {
   return _cmdPush;
-}
-
-void Button::handleCommand()
-{
-  handle();
-  if (pressed())
-  {
-    XP.commandStart(_cmdPush);
-  }
-  if (released())
-  {
-    XP.commandEnd(_cmdPush);
-  }
-}
-
-void Button::handleCommand(bool input)
-{
-  handle(input);
-  if (pressed())
-  {
-    XP.commandStart(_cmdPush);
-  }
-  if (released())
-  {
-    XP.commandEnd(_cmdPush);
-  }
 }
 
 RepeatButton::RepeatButton(uint8_t mux, uint8_t pin, uint32_t delay) : Button(mux, pin)
@@ -137,13 +91,13 @@ void RepeatButton::handle(bool input)
     if (_state == 0)
     {
       _state = DEBOUNCE_DELAY;
-      _transition = ePressed;
+       XP.commandStart(_cmdPush);
       _timer = millis() + _delay;
     }
     else if (_delay > 0 && (millis() >= _timer))
     {
       _state = DEBOUNCE_DELAY;
-      _transition = ePressed;
+      XP.commandStart(_cmdPush);
       _timer += _delay;
     }
   }
@@ -151,7 +105,7 @@ void RepeatButton::handle(bool input)
   {
     if (--_state == 0)
     {
-      _transition = eReleased;
+      XP.commandEnd(_cmdPush);
     }
   }
 }

--- a/XPLDirectDevices/lib/Button/Button.h
+++ b/XPLDirectDevices/lib/Button/Button.h
@@ -10,18 +10,13 @@ public:
   Button(uint8_t mux, uint8_t muxpin);
   void handle();
   void handle(bool input);
-  bool pressed();
-  bool released();
   bool engaged();
   void setCommand(int cmdPush);
-  int getCommand();
-  void handleCommand();
-  void handleCommand(bool input);
+  int  getCommand();
 protected:
   uint8_t _mux;
   uint8_t _pin;
   uint8_t _state;
-  uint8_t _transition;
   int _cmdPush;
 };
 


### PR DESCRIPTION
This is a proposal to simplify event handling (just applied to Button class as example).
For events bound to XP, the _transition variable doesn't add anything;
it could be argued that it could be used by other parts of the code, but since it is reset when read by the first coming reader, we would have to solve a race condition (option: if it is really desired for this purpose, do not remove the _transition variable management,  but leave the XP command events in place, so they would not use _transition).
